### PR TITLE
feat: support search across pages

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -4,6 +4,7 @@ pub mod meta;
 pub mod outline;
 pub mod project;
 pub mod render;
+pub mod search;
 pub mod theme;
 pub mod utils;
 pub mod version;

--- a/cli/src/search.rs
+++ b/cli/src/search.rs
@@ -1,0 +1,10 @@
+use std::path::Path;
+
+use crate::project::Project;
+
+impl Project {
+    pub fn index_search(&self, description: &str, page_path: &Path) {
+        let _ = description;
+        let _ = page_path;
+    }
+}


### PR DESCRIPTION
We can borrow solution from https://github.com/rust-lang/mdBook/blob/v0.4.43/src/renderer/html_handlebars/search.rs

It should be great enough that our first PR only supports to search first 512 characters of each chapters. Then we can also extract headings and adds them to the search indices.
