### PR TITLE
fix: ensure wasm module matches frontend build

### DIFF
--- a/tools/build-from-source/src/main.rs
+++ b/tools/build-from-source/src/main.rs
@@ -40,6 +40,12 @@ fn main() -> anyhow::Result<()> {
     let dst = project.join("assets/artifacts/book.mjs");
     std::fs::copy(src, dst)?;
 
+    // copy typst ts renderer wasm module
+    let src =
+        project.join("node_modules/@myriaddreamin/typst-ts-renderer/pkg/typst_ts_renderer_bg.wasm");
+    let dst = project.join("assets/artifacts/typst_ts_renderer_bg.wasm");
+    std::fs::copy(src, dst)?;
+
     println!("Running cargo build...");
     let mut cmd = Command::new("cargo");
     cmd.args(["build", "--release"]);


### PR DESCRIPTION
The frontend is built against the `typst_ts_renderer_bg.wasm` installed in node_modules. However, the cli ships a prebuilt `typst_ts_renderer_bg.wasm` from https://github.com/Myriad-Dreamin/typst/tree/assets-book-v0.2.0 . This mismatch can cause wasm load failures(#100).

This PR fixes it by copying the wasm module from node_modules to ensure a single source of truth for `typst_ts_renderer_bg.wasm`.

Fix #100