### PR TITLE
fix: Correct outer-height value in xcommand-html

### DIFF
--- a/packages/shiroa/xcommand.typ
+++ b/packages/shiroa/xcommand.typ
@@ -78,7 +78,7 @@
         "width: "
         str(outer-width.pt())
         "px; height: "
-        str(outer-width.pt())
+        str(outer-height.pt())
         "px"
       },
     ),


### PR DESCRIPTION
This pull request fixes a bug in xcommand-html where the outer-height variable was incorrectly assigned the value of outer-width.

The code has been corrected to use outer-height, ensuring the feature functions as intended.

Resolves #170