### PR TITLE
fix: Resolve multi-byte character issue in auto description generation

### DIFF
--- a/packages/shiroa/supports-text.typ
+++ b/packages/shiroa/supports-text.typ
@@ -18,15 +18,21 @@
     return plain-text_(it.body)
   } else if it.has("children") {
     let results = ()
-    let content-sum = 0
     for child in it.children {
       let ret = plain-text_(child)
-      results.push(ret)
-      if limit != none {
-        content-sum += ret.len()
-        if content-sum >= limit {
-          break
+      if limit == none {
+        results.push(ret)
+      } else {
+        let content-sum = 0
+        let result = ()
+        for char-code in ret.codepoints().map(str.to-unicode) {
+          if content-sum >= limit {
+            break
+          }
+          content-sum += 1
+          result.push(str.from-unicode(char-code))
         }
+        results.push(result.join(""))
       }
     }
 

--- a/packages/shiroa/templates.typ
+++ b/packages/shiroa/templates.typ
@@ -290,8 +290,9 @@
 ) = {
   let description = if description != none { description } else {
     let desc = plain-text(plain-body, limit: 512).trim()
-    if desc.len() > 512 {
-      desc = desc.slice(0, 512) + "..."
+    let desc_chars = desc.codepoints()
+    if desc_chars.len() >= 512 {
+      desc = desc_chars.slice(0, 512).join("") + "..."
     }
     desc
   }


### PR DESCRIPTION
This PR fixes a bug that occurs when creating a long description with multi-byte characters without explicitly specifying the description parameter.

To address this bug, I've made the following two adjustments:

+ Unified Character Counting: The character counting for the description, which previously mixed bytes and character counts, has been unified to use Unicode code points.

+ Argument Unit Change: The limit argument for the plain-text function (which converts content to a string) now accepts the number of Unicode code points instead of bytes.

I verified that these changes have no noticeable impact on performance by running both the patched code and the original code (with the buggy part removed) three times each.

Fixes: #172 

test code:
```typ
#import "/book.typ": book-page

#show: book-page.with(
    title: "Hello, typst",
)

#{"啊"*1024}
```