### PR TITLE
fix: init page.typ wrong book.typ path

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -153,13 +153,12 @@ Sample page
     )?;
     write_file(
         dir.join("templates/page.typ"),
-        include_str!("../../contrib/typst/gh-pages.typ").replace(
-            r#""/contrib/typst/gh-pages.typ""#,
-            &format!("{page_template:?}"),
-        ).replace(
-						r#""/github-pages/docs/book.typ""#,
-						&format!("{book_typ:?}")
-				),
+        include_str!("../../contrib/typst/gh-pages.typ")
+            .replace(
+                r#""/contrib/typst/gh-pages.typ""#,
+                &format!("{page_template:?}"),
+            )
+            .replace(r#""/github-pages/docs/book.typ""#, &format!("{book_typ:?}")),
     )?;
     write_file(
         dir.join("templates/ebook.typ"),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -156,7 +156,10 @@ Sample page
         include_str!("../../contrib/typst/gh-pages.typ").replace(
             r#""/contrib/typst/gh-pages.typ""#,
             &format!("{page_template:?}"),
-        ),
+        ).replace(
+						r#""/github-pages/docs/book.typ""#,
+						&format!("{book_typ:?}")
+				),
     )?;
     write_file(
         dir.join("templates/ebook.typ"),


### PR DESCRIPTION
```
> shiroa init book
package shiroa/0.2.3 already exists
package shiroa-starlight/0.2.3 already exists
package shiroa-mdbook/0.2.3 already exists
       Hint: Server started at http://127.0.0.1:25520
   Compiling sample-page.typ
error: file not found (searched at /path/to/book/github-pages/docs/book.typ)
    ┌─ /path/to/book/templates/page.typ:112:23
    │
112 │     book-meta: include "/github-pages/docs/book.typ",
    │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

      Error: sample-page.typ: compile error: compile page failed, with []
```