### PR TITLE
fix: pull fix of CVE 2025-55159 (tokio-rs/slab)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3355,9 +3355,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slotmap"


### PR DESCRIPTION
note: this is not a security update, because our CLI doesn't use the function related to the fix.